### PR TITLE
0.1.5

### DIFF
--- a/src/components/table/useDataTable.jsx
+++ b/src/components/table/useDataTable.jsx
@@ -71,7 +71,7 @@ function useDataTable(
     ]
   );
 
-  return [data, tableNode, refetch];
+  return [data, tableNode, refetch, tableStateReducer];
 }
 
 export default useDataTable;


### PR DESCRIPTION
added tableStateReducer to the fields returned by useDataTable. In this way is possible to reset the state of the table from outside. This is helpful in case the table URL params depends on UI components outside the table.