### PR TITLE
feat: add filterPlaceholder support to DefaultColumnFilter

### DIFF
--- a/src/components/table/filters.jsx
+++ b/src/components/table/filters.jsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { Input } from "reactstrap";
 
 // Define a default UI for filtering
-function DefaultColumnFilter({ column: { filterValue, setFilter, id } }) {
+function DefaultColumnFilter({ column: { filterValue, setFilter, id, filterPlaceholder } }) {
   // state
   const [inputValue, setInputValue] = React.useState(
     filterValue !== undefined ? filterValue : "",
@@ -48,7 +48,7 @@ function DefaultColumnFilter({ column: { filterValue, setFilter, id } }) {
         // if copy-paste is done, the request is sent automatically
         setFilter(e.clipboardData.getData("text/plain") || undefined);
       }}
-      placeholder="Search keyword.."
+      placeholder={filterPlaceholder || "Search keyword.."}
     />
   );
 }


### PR DESCRIPTION
## Description

Added support for an optional `filterPlaceholder` prop in [DefaultColumnFilter] component.

This allows consumers (like IntelOwl) to customize the placeholder text for specific columns (e.g., showing "Search ID" instead of the default "Search keyword..").

### Changes
- [DefaultColumnFilter] now accepts `filterPlaceholder` from the column definition
- If `filterPlaceholder` is provided, it is used as the input placeholder
- If not provided, falls back to the default `"Search keyword.."` (backward compatible)

### Related
- IntelOwl Issue: https://github.com/intelowlproject/IntelOwl/issues/1553
